### PR TITLE
Fix rosbuild with newer ros versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/src
   ${DSO_PATH}/src
   ${DSO_PATH}/thirdparty/Sophus
+  ${OpenCV_INCLUDE_DIRS}
   ${Pangolin_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIR}
 )  

--- a/manifest.xml
+++ b/manifest.xml
@@ -8,6 +8,7 @@
   <license>see http://vision.in.tum.de/dso</license>
   <review status="unreviewed" notes=""/>
   <url>http://vision.in.tum.de/dso</url>
+  <depend package="roscpp"/>
   <depend package="roslib"/>
   <depend package="cv_bridge"/>
   <depend package="sensor_msgs"/>


### PR DESCRIPTION
Fixes build issues with newer versions of rosbuild and with OpenCV 3 (which is default in kinetic).