### PR TITLE
Cmake, travis, and others

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,67 @@
+dist: trusty
+sudo: enabled
+language: cpp
+cache: ccache
+
+compiler:
+  - gcc
+env:
+  global:
+    - ROS_DISTRO=indigo
+  matrix:
+    - BUILD_TYPE=Release
+    - BUILD_TYPE=Debug
+
+# get c++14 compatible gcc version
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-5
+      - g++-5
+
+before_install:
+  - CC=gcc-5 && CXX=g++-5
+  - export CI_SOURCE_PATH=$(pwd)
+  - export REPOSITORY_NAME=${PWD##*/}
+  - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
+  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin ros-$ROS_DISTRO-ros python-rosinstall python-catkin-tools
+  # Setup rosdep
+  - sudo rosdep init
+  - rosdep update
+
+install:
+  # Create workspace
+  - mkdir -p ~/ros/ws_$REPOSITORY_NAME
+  - cd ~/ros/ws_$REPOSITORY_NAME
+  - catkin config --init --mkdirs
+  - cd src
+  # Clone dependencies
+  # FXIME: get upstream branches after PRs are merged
+  - git clone -b cmake https://github.com/NikolausDemmel/dso
+  # Link the repo we are testing to the new workspace
+  - ln -s $CI_SOURCE_PATH .
+  # Install DSO dependencies (not handled by rosdep)
+  - cd dso
+  - scripts/ci-install-linux-deps.sh
+  # Install additional dependencies for source repos with rosdep
+  - cd ~/ros/ws_$REPOSITORY_NAME
+  - rosdep install -r -n --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
+
+before_script:
+  - source /opt/ros/$ROS_DISTRO/setup.bash
+  - rospack profile
+
+script:
+  - cd ~/ros/ws_$REPOSITORY_NAME
+  - catkin config -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+  - catkin build -j4 --verbose --summary --no-status
+  #- catkin run_tests -p1 -j4 --summary
+  #- catkin_test_results --all ~/ros/ws_$REPOSITORY_NAME/build
+
+#after_failure:
+#  - find ~/ros/ws_$REPOSITORY_NAME/build -path '*/test_results/*' -type f -exec echo "==== {} ====" \; -exec cat {} \;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,59 @@ find_package(catkin REQUIRED COMPONENTS
   cv_bridge
 )
 
-set(DSO_PATH $ENV{DSO_PATH})
-message("\n\n---- LOOKING FOR DSO at\n\"${DSO_PATH}\"")
+# TODO: add cmake config files to dso such that it is picked up automatically, like pangolin!
+
+##########################################################################
+# You can set DSO_PATH to your source folder by passing
+# `-DDSO_PATH=...`, setting environment variables, or by uncommenting
+# the following lines. DSO_LIBRARY_PATH defaults to "${DSO_PATH}/build/lib.
+#
+# If DSO_PATH is not set, we'll try to find a DSO install with cmake
+# (which also works in works with DSO installed in the devel folder).
+##########################################################################
+
+#set(DSO_PATH         /home/user/dso)
+#set(DSO_LIBRARY_PATH /home/user/build-dso)
+
+# set values from environment variables
+if (NOT DSO_PATH)
+    set(DSO_PATH $ENV{DSO_PATH})
+endif()
+if (NOT DSO_LIBRARY_PATH)
+    set(DSO_LIBRARY_PATH $ENV{DSO_LIBRARY_PATH})
+    if (NOT DSO_LIBRARY_PATH AND DSO_PATH)
+        set(DSO_LIBRARY_PATH "${DSO_PATH}/build/lib")
+    endif()
+endif()
+
+if (DSO_PATH)
+    # Manually set path to DSO source folder
+    message("DSO_PATH set, trying to find library.")
+    message("---- EXPECTING DSO sources at\n\"${DSO_PATH}\"")
+    set(DSO_INCLUDE_DIRS "${DSO_PATH}/src" "${DSO_PATH}/thirdparty/Sophus")
+    message("---- LOOKING FOR DSO library at\n\"${DSO_LIBRARY_PATH}\"")
+    find_library(DSO_LIBRARY dso ${DSO_LIBRARY_PATH})
+else()
+    # Detect DSO install (also catkin devel folder)
+    message("DSO_PATH not set yet, trying to find installed dso headers and library.")
+    find_path(DSO_INCLUDE_DIRS dso)
+    if (DSO_INCLUDE_DIRS)
+        set(DSO_INCLUDE_DIRS "${DSO_INCLUDE_DIRS}/dso")
+        message("---- FOUND DSO headers at \"${DSO_INCLUDE_DIRS}\"")
+    endif()
+    find_library(DSO_LIBRARY dso)
+endif()
+
+
+if (NOT DSO_INCLUDE_DIRS)
+    message(FATAL_ERROR "DSO headers not found and/or DSO_PATH not set.")
+endif()
+if (NOT DSO_LIBRARY)
+    message(FATAL_ERROR "DSO library not found and/or DSO_LIBRARY_PATH not set.")
+endif()
+
+message("---- Found DSO library at \"${DSO_LIBRARY}\"")
+
 
 
 find_package(Pangolin 0.2 REQUIRED)
@@ -22,7 +73,6 @@ message("---- FOUND OpenCV Libs at\n\"${OpenCV_LIBS}\"")
 
 find_package(Eigen3 REQUIRED)
 find_package(Boost COMPONENTS system thread)
-find_library(DSO_LIBRARY dso ${DSO_PATH}/build/lib)
 
 catkin_package(
   CATKIN_DEPENDS
@@ -42,8 +92,7 @@ set(CMAKE_CXX_FLAGS
 
 include_directories(
   ${PROJECT_SOURCE_DIR}/src
-  ${DSO_PATH}/src
-  ${DSO_PATH}/thirdparty/Sophus
+  ${DSO_INCLUDE_DIRS}
   ${Pangolin_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIR}
   ${catkin_INCLUDE_DIRS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,8 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS
-   "${SSE_FLAGS} -O2 -g -std=c++0x -march=native -fno-omit-frame-pointer"
+set(CMAKE_CXX_FLAGS "-std=c++14 -march=native"
+#   "${SSE_FLAGS} -O2 -g -std=c++0x -march=native -fno-omit-frame-pointer"
 )
 
 include_directories(

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>dso_ros</name>
   <version>1.0.0</version>
   <description>
@@ -17,14 +17,10 @@
   <url>http://vision.in.tum.de/dso</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>cv_bridge</build_depend>
 
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>cv_bridge</run_depend>
-
+  <depend>dso</depend>
+  <depend>geometry_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>cv_bridge</depend>
 </package>


### PR DESCRIPTION
This is supposed to accompany https://github.com/JakobEngel/dso/pull/109

- Add travis build check (for now against my fork, until https://github.com/JakobEngel/dso/pull/109 is merged)
- Add more ways to find DSO. If it is built in catkin workspace, it is picked up automatically. If not, you can still set DSO_PATH manually.
- compiler flags updated to match https://github.com/JakobEngel/dso/pull/109
- updated package.xml