### PR TITLE
Added dump to file on finish

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@
 std::string calib = "";
 std::string vignetteFile = "";
 std::string gammaFile = "";
+std::string saveFile = "";
 bool useSampleOutput=false;
 
 using namespace dso;
@@ -126,7 +127,13 @@ void parseArgument(char* arg)
 		printf("loading gammaCalib from %s!\n", gammaFile.c_str());
 		return;
 	}
-
+	
+	if(1==sscanf(arg,"savefile=%s",buf))
+	{
+		saveFile = buf;
+		printf("saving to %s on finish!\n", saveFile.c_str());
+		return;
+	}
 	printf("could not parse argument \"%s\"!!\n", arg);
 }
 
@@ -159,6 +166,7 @@ void vidCb(const sensor_msgs::ImageConstPtr img)
 
 	MinimalImageB minImg((int)cv_ptr->image.cols, (int)cv_ptr->image.rows,(unsigned char*)cv_ptr->image.data);
 	ImageAndExposure* undistImg = undistorter->undistort<unsigned char>(&minImg, 1,0, 1.0f);
+	undistImg->timestamp=img->header.stamp.toSec(); // relay the timestamp to dso
 	fullSystem->addActiveFrame(undistImg, frameID);
 	frameID++;
 	delete undistImg;
@@ -224,7 +232,7 @@ int main( int argc, char** argv )
     ros::Subscriber imgSub = nh.subscribe("image", 1, &vidCb);
 
     ros::spin();
-
+    fullSystem->printResult(saveFile);
     for(IOWrap::Output3DWrapper* ow : fullSystem->outputWrapper)
     {
         ow->join();


### PR DESCRIPTION
These changes add the option for a save file at the end of the node's life to dump the trajectory with image timestamps. This change also added a timestamp to the images which are passed into dso.